### PR TITLE
Add expect macros

### DIFF
--- a/ekotrace-capi/ctest/noop.c
+++ b/ekotrace-capi/ctest/noop.c
@@ -82,5 +82,8 @@ int main(void) {
     err = EKOTRACE_RECORD_W_F32(g_tracer, EVENT_A, 0.0f);
     assert(err == EKOTRACE_RESULT_OK);
 
+    err = EKOTRACE_EXPECT(g_tracer, EVENT_A, 1 == 0);
+    assert(err == EKOTRACE_RESULT_OK);
+
     return 0;
 }

--- a/ekotrace-capi/ctest/test.c
+++ b/ekotrace-capi/ctest/test.c
@@ -134,6 +134,11 @@ bool test_event_recording(void) {
         fprintf(stderr, "failed at record event with payload: %d\n", result);
         passed = false;
     }
+    result = EKOTRACE_EXPECT(t, EVENT_A, 1 == 0, "my docs", "tags=severity.10");
+    if (result != EKOTRACE_RESULT_OK) {
+        fprintf(stderr, "failed at expect: %d\n", result);
+        passed = false;
+    }
     causal_snapshot snap_b;
     result = ekotrace_distribute_fixed_size_snapshot(t, &snap_b);
     if (result != EKOTRACE_RESULT_OK) {

--- a/ekotrace-capi/ekotrace-capi-impl/src/lib.rs
+++ b/ekotrace-capi/ekotrace-capi-impl/src/lib.rs
@@ -338,8 +338,9 @@ assert_eq_align!(u16, ChunkedReportToken);
 /// `ekotrace_write_next_report_chunk` and `ekotrace_finish_chunked_report`
 ///
 /// Once this method has been called, mutating operations on
-/// the Ekotrace instance will return `EKOTRACE_RESULT_REPORT_LOCK_CONFLICT_ERROR`
-/// until all available chunks have been written with  `ekotrace_write_next_report_chunk`
+/// the Ekotrace instance will return
+/// `EKOTRACE_RESULT_REPORT_LOCK_CONFLICT_ERROR` until all available chunks have
+/// been written with  `ekotrace_write_next_report_chunk`
 /// and `ekotrace_finish_chunked_report` called.
 ///
 /// # Safety
@@ -520,7 +521,8 @@ mod tests {
         assert_eq!(1, snap_b_neighborhood.clocks_len);
         assert!(snap_b < snap_b_neighborhood);
 
-        // Share that snapshot with another component in the system, pretend it lives on some other thread.
+        // Share that snapshot with another component in the system, pretend it lives on
+        // some other thread.
         let remote_tracer_id = tracer_id + 1;
 
         let mut remote_storage = [0u8; 1024];
@@ -537,7 +539,8 @@ mod tests {
         assert_eq!(EKOTRACE_RESULT_OK, result);
         let remote_tracer = unsafe { remote_tracer.assume_init() };
         let remote_snap_pre_merge = stack_snapshot(remote_tracer);
-        // Since we haven't manually combined history information yet, the remote's history is disjoint
+        // Since we haven't manually combined history information yet, the remote's
+        // history is disjoint
         assert_eq!(
             None,
             remote_snap_pre_merge.partial_cmp(&snap_b_neighborhood)

--- a/ekotrace-capi/include/ekotrace.h
+++ b/ekotrace-capi/include/ekotrace.h
@@ -220,6 +220,24 @@ typedef struct causal_snapshot {
             payload) : EKOTRACE_RESULT_OK)
 
 /*
+ * Ekotrace expectation expression event recording macro.
+ *
+ * Used to expose expectation event recording information to the CLI tooling.
+ *
+ * Expands to call `ekotrace_record_event_with_payload_u32(ekt, event, expression_outcome)`.
+ *
+ * The trailing variadic macro arguments accept (in any order):
+ * - A string for declaring tags: "tags=<tag>[;<tag>]"
+ * - A string for the event description
+ *
+ */
+#define EKOTRACE_EXPECT(ekt, event, expr, ...) \
+    ((EKOTRACE_MACROS_ENABLED) ? ekotrace_record_event_with_payload_u32(\
+            ekt, \
+            event, \
+            (expr)) : EKOTRACE_RESULT_OK)
+
+/*
  * Create a ekotrace instance. ekotrace_id must be non-zero
  */
 size_t ekotrace_initialize(uint8_t *destination, size_t destination_size_bytes, uint32_t ekotrace_id, ekotrace * * out);

--- a/examples/event-recording.rs
+++ b/examples/event-recording.rs
@@ -12,7 +12,9 @@
 mod tracing_ids;
 
 use crate::tracing_ids::*;
-use ekotrace::{try_initialize_at, try_record, try_record_w_u32, BulkReporter, Ekotrace};
+use ekotrace::{
+    try_expect, try_initialize_at, try_record, try_record_w_u32, BulkReporter, Ekotrace,
+};
 use std::net::UdpSocket;
 use std::{thread, time};
 
@@ -36,6 +38,15 @@ fn main() {
             TOP_OF_THE_LOOP,
             "At the top of the loop",
             "tags=example;my-tag"
+        )
+        .expect("Could not record event");
+
+        try_expect!(
+            tracer,
+            MOD10_CONDITION_EVENT,
+            loop_counter % 10 == 0,
+            "Loop counter % 10 event",
+            "tags=example"
         )
         .expect("Could not record event");
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -418,6 +418,46 @@ macro_rules! try_record_w_f32 {
     }};
 }
 
+/// Convenience macro that calls
+/// [Ekotrace::record_event_with_payload](struct.Ekotrace.html#method.record_event_with_payload).
+///
+/// The optional description and tags string arguments are only used
+/// by the CLI and compile away.
+///
+/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
+#[macro_export(local_inner_macros)]
+macro_rules! expect {
+    ($tracer:expr, $event:expr, $expression:expr) => {{
+        __record_with!($tracer, $event, $expression)
+    }};
+    ($tracer:expr, $event:expr, $expression:expr, $desc_or_tags:tt) => {{
+        __record_with!($tracer, $event, $expression)
+    }};
+    ($tracer:expr, $event:expr, $expression:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+        __record_with!($tracer, $event, $expression)
+    }};
+}
+
+/// Convenience macro that calls
+/// [Ekotrace::try_record_event_with_payload](struct.Ekotrace.html#method.try_record_event_with_payload).
+///
+/// The optional description and tags string arguments are only used
+/// by the CLI and compile away.
+///
+/// The format for the tags string is: `"tags=<tag>[;<tag>]"`
+#[macro_export(local_inner_macros)]
+macro_rules! try_expect {
+    ($tracer:expr, $event:expr, $expression:expr) => {{
+        __try_record_with!($tracer, $event, $expression)
+    }};
+    ($tracer:expr, $event:expr, $expression:expr, $desc_or_tags:tt) => {{
+        __try_record_with!($tracer, $event, $expression)
+    }};
+    ($tracer:expr, $event:expr, $expression:expr, $desc_or_tags:tt, $tags_or_desc:tt) => {{
+        __try_record_with!($tracer, $event, $expression)
+    }};
+}
+
 #[doc(hidden)]
 #[macro_export(local_inner_macros)]
 macro_rules! __record_with {
@@ -556,6 +596,22 @@ mod tests {
         try_record_w_u32!(tracer, EVENT_D, 0, "tags=some-tag", "desc").unwrap();
         try_record_w_bool!(tracer, EVENT_D, false, "tags=some-tag", "desc").unwrap();
         try_record_w_f32!(tracer, EVENT_D, 0.0, "tags=some-tag", "desc").unwrap();
+
+        expect!(tracer, EventId::new(EVENT_D).unwrap(), 1 == 0);
+        expect!(tracer, EventId::new(EVENT_D).unwrap(), 1_i8 == 0_i8, "desc");
+        expect!(
+            tracer,
+            EventId::new(EVENT_D).unwrap(),
+            "s1" != "s2",
+            "tags=severity.1",
+            "desc"
+        );
+
+        try_expect!(tracer, EVENT_D, true == true).unwrap();
+        try_expect!(tracer, EVENT_D, 1 == (2 - 1), "desc").unwrap();
+        let a = 1;
+        let b = 2;
+        try_expect!(tracer, EVENT_D, a != b, "desc", "tags=my expectation").unwrap();
     }
 
     #[test]


### PR DESCRIPTION
* Adds convenience macros for recording an event where the payload is the result of an expression
* Automatically inserts an "expectation" tag in the manifest if needed

The parser implementations are getting a bit wild, I'm going to cleanup them in #117.