### PR TITLE
Header-gen takes internal events as an argument

### DIFF
--- a/ekotrace-cli/src/events.rs
+++ b/ekotrace-cli/src/events.rs
@@ -110,11 +110,7 @@ impl Events {
         events_writer.flush().expect("Can't flush events writer");
     }
 
-    pub fn next_available_event_id(&self) -> u32 {
-        let internal_events: Vec<u32> = ekotrace::EventId::INTERNAL_EVENTS
-            .iter()
-            .map(|id| id.get_raw())
-            .collect();
+    pub fn next_available_event_id(&self, internal_events: &[u32]) -> u32 {
         // Event IDs start at 1
         1 + self
             .events
@@ -174,10 +170,14 @@ mod tests {
 
     #[test]
     fn next_available_id_skips_internal_ids() {
+        let internal_events: Vec<u32> = ekotrace::EventId::INTERNAL_EVENTS
+            .iter()
+            .map(|id| id.get_raw())
+            .collect();
         let e = Events {
             path: PathBuf::from("."),
             events: Events::internal_events(),
         };
-        assert_eq!(e.next_available_event_id(), 1);
+        assert_eq!(e.next_available_event_id(&internal_events), 1);
     }
 }

--- a/ekotrace-cli/src/header_gen.rs
+++ b/ekotrace-cli/src/header_gen.rs
@@ -147,7 +147,7 @@ fn file_sha256(path: &Path) -> String {
     format!("{:x}", sha256.result())
 }
 
-pub fn run(opt: Opt) {
+pub fn run(opt: Opt, internal_events: Vec<u32>) {
     opt.validate();
 
     let tracers_csv_hash = file_sha256(&opt.tracers_csv_file);
@@ -199,10 +199,6 @@ pub fn run(opt: Opt) {
     println!(" * Events (csv sha256sum {})", events_csv_hash);
     println!(" */");
 
-    let internal_events: Vec<u32> = ekotrace::EventId::INTERNAL_EVENTS
-        .iter()
-        .map(|id| id.get_raw())
-        .collect();
     for maybe_event in events_reader.deserialize() {
         let e: Event = maybe_event.expect("Can't deserialize event");
         if internal_events.contains(&e.id.0) {

--- a/ekotrace-cli/src/main.rs
+++ b/ekotrace-cli/src/main.rs
@@ -177,9 +177,14 @@ impl From<Analysis> for analysis::Opt {
 fn main() {
     let opt = Opt::from_args();
 
+    let internal_events: Vec<u32> = ekotrace::EventId::INTERNAL_EVENTS
+        .iter()
+        .map(|id| id.get_raw())
+        .collect();
+
     match opt {
         Opt::ManifestGen(opt) => manifest_gen::run(opt.into()),
-        Opt::HeaderGen(opt) => header_gen::run(opt.into()),
+        Opt::HeaderGen(opt) => header_gen::run(opt.into(), internal_events),
         Opt::Analysis(opt) => analysis::run(opt.into()),
     }
 }

--- a/ekotrace-cli/src/manifest_gen/invocations.rs
+++ b/ekotrace-cli/src/manifest_gen/invocations.rs
@@ -448,11 +448,13 @@ impl<'cfg> Invocations<'cfg> {
                 }
             });
 
+        let internal_events: Vec<u32> = self.internal_events.iter().map(|e| e.id.0).collect();
         let event_id_offset = event_id_offset.unwrap_or(0);
-        let mut next_available_event_id: u32 = match mf_events.next_available_event_id() {
-            id if event_id_offset > id => event_id_offset,
-            id => id,
-        };
+        let mut next_available_event_id: u32 =
+            match mf_events.next_available_event_id(&internal_events) {
+                id if event_id_offset > id => event_id_offset,
+                id => id,
+            };
 
         self.events.iter().for_each(|src_event| {
             if mf_events.events.iter().find(|e| src_event.eq(e)).is_none() {
@@ -468,7 +470,6 @@ impl<'cfg> Invocations<'cfg> {
             }
         });
 
-        let internal_events: Vec<u32> = self.internal_events.iter().map(|e| e.id.0).collect();
         mf_events
             .events
             .iter()


### PR DESCRIPTION
This commit enables users of the library to provide a set of internal events to be excluded when generating the header file definitions.