### PR TITLE
Header-gen output to file or stdout

### DIFF
--- a/ekotrace-cli/src/main.rs
+++ b/ekotrace-cli/src/main.rs
@@ -70,6 +70,10 @@ pub struct HeaderGen {
     /// C header include guard prefix
     #[structopt(long, default_value = "EKOTRACE")]
     include_guard_prefix: String,
+
+    /// Write output to file (instead of stdout)
+    #[structopt(short = "o", long, parse(from_os_str))]
+    output_path: Option<PathBuf>,
 }
 
 #[derive(Debug, StructOpt)]
@@ -137,6 +141,7 @@ impl From<HeaderGen> for header_gen::Opt {
             tracers_csv_file: opt.tracers_csv_file,
             lang: opt.lang,
             include_guard_prefix: opt.include_guard_prefix,
+            output_path: opt.output_path,
         }
     }
 }

--- a/ekotrace-cli/src/manifest_gen/mod.rs
+++ b/ekotrace-cli/src/manifest_gen/mod.rs
@@ -14,7 +14,7 @@ pub mod source_location;
 pub mod tracer_metadata;
 pub mod type_hint;
 
-#[derive(Debug)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug)]
 pub struct Opt {
     pub lang: Option<Lang>,
     pub event_id_offset: Option<u32>,
@@ -25,6 +25,22 @@ pub struct Opt {
     pub no_events: bool,
     pub no_tracers: bool,
     pub source_path: PathBuf,
+}
+
+impl Default for Opt {
+    fn default() -> Self {
+        Opt {
+            lang: None,
+            event_id_offset: None,
+            tracer_id_offset: None,
+            file_extensions: None,
+            events_csv_file: PathBuf::from("events.csv"),
+            tracers_csv_file: PathBuf::from("tracers.csv"),
+            no_events: false,
+            no_tracers: false,
+            source_path: PathBuf::from("."),
+        }
+    }
 }
 
 impl Opt {


### PR DESCRIPTION
This commit adds an optional output path to header-gen, defaults
to stdout when not specified.