### PR TITLE
Make error mod more accessible to library consumers

### DIFF
--- a/modality-probe-cli/src/error.rs
+++ b/modality-probe-cli/src/error.rs
@@ -2,29 +2,29 @@ use std::{fmt::Display, process::exit};
 
 #[macro_export]
 macro_rules! warn {
-    ($prefix:expr, $tag:expr, $msg:expr) => {{
-        eprintln!("{} {}: warning: {}", $prefix, $tag, $msg);
+    ($tag:expr, $msg:expr) => {{
+        eprintln!("modality-probe {}: warning: {}", $tag, $msg);
     }};
-     ($prefix:expr, $tag:expr, $fmt:expr, $($arg:tt)+) => ({
-        eprint!("{} {}: warning: ", $prefix, $tag);
+     ($tag:expr, $fmt:expr, $($arg:tt)+) => ({
+        eprint!("modality-probe {}: warning: ", $tag);
         eprintln!($fmt, $($arg)*);
     });
 }
 
 #[macro_export]
 macro_rules! exit_error {
-    ($prefix:expr, $tag:expr, $msg:expr) => {{
-        eprintln!("{} {}: error: {}", $prefix, $tag, $msg);
+    ($tag:expr, $msg:expr) => {{
+        eprintln!("modality-probe {}: error: {}", $tag, $msg);
         std::process::exit(1);
     }};
-     ($prefix:expr, $tag:expr, $fmt:expr, $($arg:tt)+) => ({
-        eprint!("{} {}: error: ", $prefix, $tag);
+    ($tag:expr, $fmt:expr, $($arg:tt)+) => ({
+        eprint!("modality-probe {}: error: ", $tag);
         eprintln!($fmt, $($arg)*);
         std::process::exit(1);
     });
 }
 
-pub(crate) trait GracefulExit<T> {
+pub trait GracefulExit<T> {
     fn unwrap_or_exit(self, msg: &str) -> T;
 }
 
@@ -32,6 +32,15 @@ impl<T, E: Display> GracefulExit<T> for Result<T, E> {
     fn unwrap_or_exit(self, msg: &str) -> T {
         self.unwrap_or_else(|e| {
             eprintln!("modality-probe {}: error: {}", msg, e);
+            exit(1);
+        })
+    }
+}
+
+impl<T> GracefulExit<T> for Option<T> {
+    fn unwrap_or_exit(self, msg: &str) -> T {
+        self.unwrap_or_else(|| {
+            eprintln!("modality-probe error: {}", msg);
             exit(1);
         })
     }

--- a/modality-probe-cli/src/export.rs
+++ b/modality-probe-cli/src/export.rs
@@ -9,21 +9,21 @@ use modality_probe_graph::{digraph::Digraph, meta::*, Cfg};
 
 /// Export a textual representation of a causal graph using the
 /// collected coumnar form as input.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, PartialEq, StructOpt)]
 pub struct Export {
     /// Generate the graph showing only the causal relationships,
     /// eliding the events inbetween.
     #[structopt(long)]
-    interactions_only: bool,
+    pub interactions_only: bool,
     /// The path the probes.csv for a component.
     #[structopt(long)]
-    probes: PathBuf,
+    pub probes: PathBuf,
     /// The path the events.csv for a component.
     #[structopt(long)]
-    events: PathBuf,
+    pub events: PathBuf,
     /// The path to the file containing the collected traces.
     #[structopt(long)]
-    report: PathBuf,
+    pub report: PathBuf,
     /// The type of graph to output.
     ///
     /// This can be either `cyclic` or `acyclic`.
@@ -33,10 +33,10 @@ pub struct Export {
     ///
     /// * An acyclic graph shows the causal history of either all
     /// events or the interactions between traces in the system.
-    graph_type: GraphType,
+    pub graph_type: GraphType,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, PartialEq, StructOpt)]
 pub enum GraphType {
     Cyclic,
     Acyclic,

--- a/modality-probe-cli/src/lib.rs
+++ b/modality-probe-cli/src/lib.rs
@@ -1,5 +1,4 @@
-mod error;
-
+pub mod error;
 pub mod events;
 pub mod export;
 pub mod header_gen;

--- a/modality-probe-cli/src/main.rs
+++ b/modality-probe-cli/src/main.rs
@@ -1,4 +1,4 @@
-use modality_probe_cli::{export, header_gen, manifest_gen, opts::*};
+use modality_probe_cli::{error::GracefulExit, export, header_gen, manifest_gen, opts::Opts};
 use structopt::StructOpt;
 
 fn main() {
@@ -12,10 +12,6 @@ fn main() {
     match opts {
         Opts::ManifestGen(opt) => manifest_gen::run(opt),
         Opts::HeaderGen(opt) => header_gen::run(opt, internal_events),
-        Opts::Export(exp) => {
-            if let Err(e) = export::run(exp) {
-                println!("Error: {}", e);
-            }
-        }
+        Opts::Export(exp) => export::run(exp).unwrap_or_exit("export"),
     }
 }

--- a/modality-probe-cli/src/manifest_gen/invocations.rs
+++ b/modality-probe-cli/src/manifest_gen/invocations.rs
@@ -41,20 +41,16 @@ pub enum EventCheckError {
     NameNotUpperCase(InSourceEvent),
 }
 
-pub struct Invocations<'cfg> {
-    pub log_prefix: &'cfg str,
-    pub log_module: &'cfg str,
+pub struct Invocations {
     pub internal_events: Vec<Event>,
     pub probes: Vec<InSourceProbe>,
     pub events: Vec<InSourceEvent>,
 }
 
-impl<'cfg> Default for Invocations<'cfg> {
+impl Default for Invocations {
     fn default() -> Self {
         let config = Config::default();
         Invocations {
-            log_prefix: config.log_prefix,
-            log_module: config.log_module,
             internal_events: config.internal_events,
             probes: Default::default(),
             events: Default::default(),
@@ -63,8 +59,6 @@ impl<'cfg> Default for Invocations<'cfg> {
 }
 
 pub struct Config<'cfg> {
-    pub log_prefix: &'cfg str,
-    pub log_module: &'cfg str,
     pub lang: Option<Lang>,
     pub no_probes: bool,
     pub no_events: bool,
@@ -77,8 +71,6 @@ pub struct Config<'cfg> {
 impl<'cfg> Default for Config<'cfg> {
     fn default() -> Self {
         Config {
-            log_prefix: "modality-probe",
-            log_module: "manifest-gen",
             lang: None,
             no_probes: false,
             no_events: false,
@@ -90,8 +82,8 @@ impl<'cfg> Default for Config<'cfg> {
     }
 }
 
-impl<'cfg> Invocations<'cfg> {
-    pub fn from_path<P: AsRef<Path>>(config: Config<'cfg>, p: P) -> Result<Self, CreationError> {
+impl Invocations {
+    pub fn from_path<P: AsRef<Path>>(config: Config<'_>, p: P) -> Result<Self, CreationError> {
         let mut probes = Vec::new();
         let mut events = Vec::new();
         let mut buffer = String::new();
@@ -139,17 +131,14 @@ impl<'cfg> Invocations<'cfg> {
                                 Some("c") => Box::new(config.c_parser),
                                 Some(ext) => {
                                     warn!(
-                                        config.log_prefix,
-                                        config.log_module,
-                                        "Guessing C parser based on file extension '{}'",
-                                        ext
+                                        "manifest-gen",
+                                        "Guessing C parser based on file extension '{}'", ext
                                     );
                                     Box::new(config.c_parser)
                                 }
                                 None => {
                                     warn!(
-                                        config.log_prefix,
-                                        config.log_module,
+                                        "manifest-gen",
                                         "Guessing C parser based on file extension '{}'",
                                         os_str.to_string_lossy()
                                     );
@@ -158,8 +147,7 @@ impl<'cfg> Invocations<'cfg> {
                             },
                             None => {
                                 warn!(
-                                    config.log_prefix,
-                                    config.log_module,
+                                    "manifest-gen",
                                     "No file extension available, defaulting to using the C parser\n\
                                     {:?}",
                                     entry.path()
@@ -200,8 +188,6 @@ impl<'cfg> Invocations<'cfg> {
             }
         }
         Ok(Invocations {
-            log_prefix: config.log_prefix,
-            log_module: config.log_module,
             internal_events: config.internal_events,
             probes,
             events,
@@ -261,8 +247,7 @@ impl<'cfg> Invocations<'cfg> {
                 .for_each(|t| {
                     if !src_probe.eq(t) {
                         warn!(
-                            self.log_prefix,
-                            self.log_module,
+                            "manifest-gen",
                             "Probe {}, ID {} may have moved\n\
                             Prior location from {}: {}:{}\n\
                             New location in source code: {}:{}:{}",
@@ -329,8 +314,7 @@ impl<'cfg> Invocations<'cfg> {
                 .is_none();
             if missing_probe {
                 warn!(
-                    self.log_prefix,
-                    self.log_module,
+                    "manifest-gen",
                     "Probe {}, ID {} in manifest no longer exists in source",
                     mf_probe.name,
                     mf_probe.id.0
@@ -361,8 +345,7 @@ impl<'cfg> Invocations<'cfg> {
                         .eq(e.line.as_str());
                     if !file_eq || !line_eq {
                         warn!(
-                            self.log_prefix,
-                            self.log_module,
+                            "manifest-gen",
                             "Event {}, ID {} may have moved\n\
                             Prior location from {}: {}:{}\n\
                             New location in source code: {}:{}:{}",
@@ -387,8 +370,7 @@ impl<'cfg> Invocations<'cfg> {
                             .map_or("", |p| p.0.as_str()),
                     ) {
                         warn!(
-                            self.log_prefix,
-                            self.log_module,
+                            "manifest-gen",
                             "Event {}, ID {} has changed its payload type\n\
                             {}:{}:{}\n\
                             Prior payload type from {}: {}\n\
@@ -482,8 +464,7 @@ impl<'cfg> Invocations<'cfg> {
                     .is_none();
                 if missing_event {
                     warn!(
-                        self.log_prefix,
-                        self.log_module,
+                        "manifest-gen",
                         "Event {}, ID {} in manifest no longer exists in source",
                         mf_event.name,
                         mf_event.id.0

--- a/modality-probe-cli/src/manifest_gen/mod.rs
+++ b/modality-probe-cli/src/manifest_gen/mod.rs
@@ -74,7 +74,6 @@ impl ManifestGen {
     pub fn validate(&self) {
         if !self.source_path.exists() {
             exit_error!(
-                "modality-probe",
                 "manifest-gen",
                 "The source path '{}' does not exist",
                 self.source_path.display()


### PR DESCRIPTION
* `pub` the error module for library users
* Use the error pattern consistently in the subcommands
* Remove the logging prefix configuration now that the product names are aligned